### PR TITLE
Correção do Cors Origin

### DIFF
--- a/errorcenter/errorcenter/settings.py
+++ b/errorcenter/errorcenter/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     # apps externos
     'rest_framework',
+    'corsheaders',
     # apps próprios
     'errors.apps.ErrorsConfig',
 ]
@@ -52,6 +53,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # apps externos
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'errorcenter.urls'
@@ -118,6 +121,10 @@ USE_L10N = True
 
 USE_TZ = True
 
+# Cross origin
+# https://pypi.org/project/django-cors-headers/
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Django==2.2.6
+django-cors-headers==3.1.1
 djangorestframework==3.10.3
+pkg-resources==0.0.0
 pytz==2019.3
 sqlparse==0.3.0


### PR DESCRIPTION
Devido a requisição realizada por Javascript ao endpoint da API, o navegador alertou sobre Cors-origin, pra corrigir isso realizei a instalação do pacote pra cors e habilitei no settings.